### PR TITLE
Add optional player sprite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 A small demo game using Pygame. It draws a pixel forest and some helicopters
 that fly back and forth. A simple player character can now run through the
-forest while dropping quips in the style of Christoph Gröner. No external assets
-are required.
+forest while dropping quips in the style of Christoph Gröner.
+
+Optionally, you can add a sprite named `Pixel-Art Geschäftsmann im Anzug.png`
+in the game directory. If present, it will be used as the player's image. The
+file itself is not included in this repository. You can download a suitable
+image from an external source (for example:
+`https://example.com/pixel-art-businessman.png`) and place it next to
+`main.py`.
 
 ## Requirements
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,11 @@ class Player:
         self.width = 20
         self.height = 30
         self.speed = 5
+        try:
+            img = pygame.image.load("Pixel-Art Geschäftsmann im Anzug.png").convert_alpha()
+            self.image = pygame.transform.scale(img, (self.width, self.height))
+        except (pygame.error, FileNotFoundError):
+            self.image = None
 
     def update(self, keys):
         if keys[pygame.K_LEFT]:
@@ -29,8 +34,11 @@ class Player:
         self.x = max(0, min(WIDTH - self.width, self.x))
 
     def draw(self, surface):
-        rect = pygame.Rect(self.x, self.y - self.height, self.width, self.height)
-        pygame.draw.rect(surface, BLACK, rect)
+        if self.image:
+            surface.blit(self.image, (self.x, self.y - self.height))
+        else:
+            rect = pygame.Rect(self.x, self.y - self.height, self.width, self.height)
+            pygame.draw.rect(surface, BLACK, rect)
 
 class Tree:
     def __init__(self, x, base_y):


### PR DESCRIPTION
## Summary
- add ability to load `Pixel-Art Geschäftsmann im Anzug.png` as player sprite
- document how to supply the external PNG

## Testing
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_684de16975348325bfdc358c755aea70